### PR TITLE
Update Samsung.json

### DIFF
--- a/data/Samsung.json
+++ b/data/Samsung.json
@@ -11,7 +11,7 @@
     },
     {
         "manufacturer": "Samsung",
-        "model": "Galaxy S2",
+        "model": "Galaxy S2 GT-i9100P",
         "OS": [
             "Android"
         ]


### PR DESCRIPTION
Only GT-i9100P is NFC enabled for the galaxy S2
